### PR TITLE
Add postal_parse(addresses text[])

### DIFF
--- a/META.json
+++ b/META.json
@@ -21,9 +21,9 @@
    },
    "provides": {
      "postal": {
-       "file": "postal--1.0.sql",
+       "file": "postal--1.1.sql",
        "docfile": "README.md",
-       "version": "1.0",
+       "version": "1.1",
        "abstract": "Postal address standardizer"
      },
    },

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 MODULE_big = postal
 OBJS = postal.o
 EXTENSION = postal
-DATA = postal--1.0.sql
+DATA = postal--1.1.sql postal--1.0--1.1.sql
 REGRESS = postal
 EXTRA_CLEAN =
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,19 @@ This extension is for that.
     (1 row)
 
 
+    =# SELECT unnest(postal_parse(postal_normalize('412 first ave, victoria, bc')));
+
+                                             unnest                                             
+    ------------------------------------------------------------------------------------------------
+     {"city": "victoria", "road": "1st avenue", "state": "british columbia", "house_number": "412"}
+     {"city": "victoria", "road": "1st avenue", "state": "bc", "house_number": "412"}
+    (2 rows)
+
 ## Functions
 
 * `postal_normalize(address TEXT)` returns `TEXT[]`
 * `postal_parse(address TEXT)` returns `JSONB`
+* `postal_parse(address TEXT[])` returns `JSONB[]`
 
 
 ## Installation

--- a/postal--1.0--1.1.sql
+++ b/postal--1.0--1.1.sql
@@ -1,0 +1,19 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION postal" to load this file. \quit
+
+-- should this return a single json array object instead?
+CREATE OR REPLACE FUNCTION postal_parse(addresses text[])
+    RETURNS jsonb[] 
+    LANGUAGE 'plpgsql' AS $$
+DECLARE
+  addrs jsonb[];
+  address text;
+  n int := 0;
+BEGIN
+  FOREACH address  IN ARRAY addresses LOOP
+    addrs[n] := postal_parse(address);
+    n := n + 1;
+  END LOOP;
+  return addrs;
+END;
+$$ IMMUTABLE STRICT;

--- a/postal--1.1.sql
+++ b/postal--1.1.sql
@@ -12,3 +12,20 @@ CREATE OR REPLACE FUNCTION postal_parse(address text)
     AS 'MODULE_PATHNAME', 'postal_parse'
     LANGUAGE 'c'
     IMMUTABLE STRICT;
+    
+-- should this return a single json array object instead?
+CREATE OR REPLACE FUNCTION postal_parse(addresses text[])
+    RETURNS jsonb[] 
+    LANGUAGE 'plpgsql' AS $$
+DECLARE
+  addrs jsonb[];
+  address text;
+  n int := 0;
+BEGIN
+  FOREACH address  IN ARRAY addresses LOOP
+    addrs[n] := postal_parse(address);
+    n := n + 1;
+  END LOOP;
+  return addrs;
+END;
+$$ IMMUTABLE STRICT;

--- a/postal.control
+++ b/postal.control
@@ -1,4 +1,4 @@
-default_version = '1.0'
+default_version = '1.1'
 module_pathname = '$libdir/postal'
 relocatable = true
 comment = 'Postal address normalizer.'


### PR DESCRIPTION
This allows us to easily feed the output of `postal_normalize()` directly into `postal_parse()`. Whether this is a good idea or not is left as an exercise to the reader.
